### PR TITLE
Enable AndroidX and Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable AndroidX and Jetifier by adding `gradle.properties`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c083728ed083299b4273c0e386b570