### PR TITLE
Increase Gradle memory limits

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Summary
- allocate more memory for Gradle by setting org.gradle.jvmargs in gradle.properties

## Testing
- `./gradlew assembleDebug` *(fails: bash: ./gradlew: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c088e72f1c832986c5ad4a68140175